### PR TITLE
Fix ThreadStatic bug in ByteStreamIn

### DIFF
--- a/ByteStreamIn.cs
+++ b/ByteStreamIn.cs
@@ -34,7 +34,18 @@ namespace LASzip.Net
 	static class ByteStreamIn
 	{
 		[ThreadStatic]
-		static byte[] buffer = new byte[8];
+		static byte[] _buffer;
+		static byte[] buffer
+		{
+			get
+			{
+				if (_buffer == null)
+				{
+					_buffer = new byte[8];
+				}
+				return _buffer;
+			}
+		}
 
 		//// read a single byte
 		//public static uint getByte(this Stream stream)


### PR DESCRIPTION
The field `buffer` in `ByteStreamIn` was only initialized for the first thread. An exception would be thrown if you use laszip.net from multiple threads because `buffer` was `null`.

See e.g. https://rules.sonarsource.com/csharp/RSPEC-2996 for more details.